### PR TITLE
Fix running arbitrary papis commands

### DIFF
--- a/papistui/tui.py
+++ b/papistui/tui.py
@@ -3,6 +3,7 @@ import io
 import os
 import shlex
 import curses
+import subprocess
 import tempfile
 from curses.textpad import Textbox
 


### PR DESCRIPTION
In the current main branch of papis-tui it is not possible to run any custom papis commands since they all fail with the general error "Execution of papis command failed".

Commit 8cb1505a42d17e3f2a9064208b3323e8def107a4 removed the subprocess module from tui.py. 
However, running `papis [...]` commands from within papis-tui using the `papis_cmd()` method requires this python module and will fail if it is not present. 

It is used in tui.py [L824](https://github.com/supersambo/papis-tui/blob/f9899182dd9b225a76dec496049fc9b581548391/papistui/tui.py#L824):

```python
run = subprocess.Popen(cmd, shell = False)
```

which will always fail if `subprocess` is not imported.

This commit simply adds the import back to fix the regression.

Beyond that, thanks for your work on this awesome interface to papis - using it almost every day for my reference management!